### PR TITLE
Add github action for publishing on pypi on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+name: Publish to PyPI.org
+on:
+  release:
+    types: [published]
+jobs:
+  pypi:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: python3 -m pip install --upgrade build && python3 -m build # build the python package
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@5fb2f047e26679d7846a8370de1642ff160b9025
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }} # Token provided by pypi.org

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = ["setuptools", "wheel"]  # PEP 508 specifications.


### PR DESCRIPTION
## Fixes #2 

#### NOTE: Before using this script please populate your github secrets with `PYPI_API_TOKEN`. After this step you can use GUI/CLI to make publishes. 

> Reference  - [publishing-python-packages-from-github-actions](https://www.seanh.cc/2022/05/21/publishing-python-packages-from-github-actions/#the-publish-workflow)