### PR TITLE
Remove the need to pass around a variable ordering in the functions that calculate the empirical copula

### DIFF
--- a/empirical_copula/__init__.py
+++ b/empirical_copula/__init__.py
@@ -106,3 +106,30 @@ def empirical_joint_pmf(samples, is_col1_ordinal=False, is_col2_ordinal=False):
     pmf1, pmf2, empirical_pmf, _ = empirical_joint_pmf_details(
         samples, is_col1_ordinal=is_col1_ordinal, is_col2_ordinal=is_col2_ordinal)
     return pmf1, pmf2, empirical_pmf
+
+
+def order_from_pmf(pmf, is_ordinal=False):
+    """ Order the pmf depending on the kind of discrete variable it contains.
+
+    An ordinal variable is ordered in ascending order of the values of the variable, a non-ordinal
+    variable is ordered by descending pmf values.
+
+    Parameters
+    ----------
+    pmf : Series
+         The pmf values for each value of a discrete variable.
+    is_ordinal : bool
+         True if the variable is ordinal.
+
+    Returns
+    -------
+    order : list
+         The list of values of the discrete variable, ordered according to its ordinality.
+
+    """
+    if is_ordinal:
+        ordered_pmf = pmf.sort_index(ascending=True)
+    else:
+        ordered_pmf = pmf.sort_values(ascending=False)
+    order = ordered_pmf.index.tolist()
+    return order

--- a/empirical_copula/__init__.py
+++ b/empirical_copula/__init__.py
@@ -3,36 +3,28 @@ __version__ = 0.1
 import pandas as pd
 
 
-def empirical_marginal_pmf(samples, is_ordinal=False):
-    """ 
+def empirical_marginal_pmf(samples):
+    """
     Compute the empirical marginals of a series of discrete variables.
-    
+
     Keyword arguments:
     samples -- a pandas Series of discrete variables
     is_ordinal -- if True, the samples are assumed to be ordered
-    
+
     Returns:
     independent_pmf -- a pandas Series of the empirical marginal probabilities
     """
     pmf = samples.value_counts(normalize=True)
-
-    if is_ordinal:
-        pmf.sort_index(ascending=True, inplace=True)
-    else:
-        pmf.sort_values(ascending=False, inplace=True)
-
     return pmf
 
 
-def joint_counts(samples, order1, order2):
+def joint_counts(samples):
     """
     DataFrame of counts of the joint distribution of two variables.
-    
+
     Keyword arguments:
     samples -- a pandas DataFrame with two columns
-    order1 -- a list of the possible values of the first variable
-    order2 -- a list of the possible values of the second variable
-    
+
     Returns:
     counts -- a DataFrame of counts of the joint distribution of the two variables
     """
@@ -41,7 +33,6 @@ def joint_counts(samples, order1, order2):
     counts = (
         samples
         .pivot_table(index=index_label, columns=columns_label, aggfunc='size', fill_value=0)
-        .loc[order1, order2]
     )
     return counts
 
@@ -49,11 +40,11 @@ def joint_counts(samples, order1, order2):
 def independent_pmf(pmf1, pmf2):
     """
     Independent dataframe
-    
+
     Keyword arguments:
     pmf1 -- a pandas Series of the empirical marginal probabilities of the first variable
     pmf2 -- a pandas Series of the empirical marginal probabilities of the second variable
-    
+
     Returns:
     independent_pmf -- a pandas DataFrame of the independent probability mass function
     """
@@ -65,46 +56,40 @@ def independent_pmf(pmf1, pmf2):
     return independent_pmf
 
 
-def empirical_joint_pmf_details(samples, is_col1_ordinal=False, is_col2_ordinal=False):
-    """
-    empirical joint pmf defails function
-    
+def empirical_joint_pmf_details(samples):
+    """ Compute the empirical joint pmf and return all the details about it.
+
     Keyword arguments:
     samples -- a pandas DataFrame with two columns
-    is_col1_ordinal -- if True, the first column is assumed to be ordered
-    is_col2_ordinal -- if True, the second column is assumed to be ordered
-    
+
     Returns:
-    pmf1 -- a pandas Series of the empirical marginal probabilities of the first variable
-    pmf2 -- a pandas Series of the empirical marginal probabilities of the second variable
+    pmf1 -- a pandas Series of the empirical marginal probabilities of the first column
+    pmf2 -- a pandas Series of the empirical marginal probabilities of the second column
     empirical_pmf -- a pandas DataFrame of the empirical joint probability mass function
     dict -- counts, joint_freqs, ind_pmf
     """
-    pmf1 = empirical_marginal_pmf(samples.iloc[:, 0], is_ordinal=is_col1_ordinal)
-    pmf2 = empirical_marginal_pmf(samples.iloc[:, 1], is_ordinal=is_col2_ordinal)
-    counts = joint_counts(samples, pmf1.index, pmf2.index)
+    pmf1 = empirical_marginal_pmf(samples.iloc[:, 0])
+    pmf2 = empirical_marginal_pmf(samples.iloc[:, 1])
+    counts = joint_counts(samples)
     joint_freq = counts / counts.sum().sum()
     ind_pmf = independent_pmf(pmf1, pmf2)
     empirical_pmf = joint_freq / ind_pmf
     return pmf1, pmf2, empirical_pmf, {'counts': counts, 'joint_freq': joint_freq, 'ind_pmf': ind_pmf}
 
 
-def empirical_joint_pmf(samples, is_col1_ordinal=False, is_col2_ordinal=False):
+def empirical_joint_pmf(samples):
     """
     empirical joint pmf function
-    
+
     Keyword arguments:
     samples -- a pandas DataFrame with two columns
-    is_col1_ordinal -- if True, the first column is assumed to be ordered
-    is_col2_ordinal -- if True, the second column is assumed to be ordered
-    
+
     Returns:
     pmf1 -- a pandas Series of the empirical marginal probabilities of the first variable
     pmf2 -- a pandas Series of the empirical marginal probabilities of the second variable
     empirical_pmf -- a pandas DataFrame of the empirical joint probability mass function
     """
-    pmf1, pmf2, empirical_pmf, _ = empirical_joint_pmf_details(
-        samples, is_col1_ordinal=is_col1_ordinal, is_col2_ordinal=is_col2_ordinal)
+    pmf1, pmf2, empirical_pmf, _ = empirical_joint_pmf_details(samples)
     return pmf1, pmf2, empirical_pmf
 
 

--- a/empirical_copula/__init__.py
+++ b/empirical_copula/__init__.py
@@ -93,7 +93,7 @@ def empirical_joint_pmf(samples):
     return pmf1, pmf2, empirical_pmf
 
 
-def order_from_pmf(pmf, is_ordinal=False):
+def order_pmf(pmf, is_ordinal=False):
     """ Order the pmf depending on the kind of discrete variable it contains.
 
     An ordinal variable is ordered in ascending order of the values of the variable, a non-ordinal
@@ -108,13 +108,11 @@ def order_from_pmf(pmf, is_ordinal=False):
 
     Returns
     -------
-    order : list
-         The list of values of the discrete variable, ordered according to its ordinality.
-
+    ordered_pmf : Series
+         The pmf values for each value of a discrete variable, ordered according to its ordinality.
     """
     if is_ordinal:
         ordered_pmf = pmf.sort_index(ascending=True)
     else:
         ordered_pmf = pmf.sort_values(ascending=False)
-    order = ordered_pmf.index.tolist()
-    return order
+    return ordered_pmf

--- a/empirical_copula/plot.py
+++ b/empirical_copula/plot.py
@@ -1,16 +1,16 @@
 import numpy as np
 
 
-def create_copula_axes(fig, pmf1, pmf2, grid_lw=1):
+def _create_copula_axes(fig, pmf1, pmf2, grid_lw):
     """
     Function to create the axes for the copula plot
-    
+
     Keyword arguments:
     fig -- a matplotlib figure
     pmf1 -- a pandas Series of the empirical marginal probabilities of the first variable
     pmf2 -- a pandas Series of the empirical marginal probabilities of the second variable
     grid_lw -- line width of the grid lines
-    
+
     Returns:
     ax -- a matplotlib Axes object
     x_mesh -- a numpy array of the x coordinates of the grid
@@ -51,3 +51,42 @@ def create_copula_axes(fig, pmf1, pmf2, grid_lw=1):
 
     y_mesh, x_mesh = np.meshgrid(values2, values1)
     return ax, x_mesh, y_mesh
+
+
+def copula_pcolormesh(fig, pmf1, pmf2, data, grid_lw=2, **pcolormesh_kwargs):
+    """ Create a copula plot.
+
+    The values in `data` are re-ordered according to the ordering of the indices of `pmf1` and
+    `pmf2`.
+
+    Parameters
+    ----------
+    fig : Figure
+        Matplotlib Figure object to plot on.
+    pmf1 : Series
+        The pmf values for each value of the first discrete variable.
+    pmf2 : Series
+        The pmf values for each value of the second discrete variable.
+    data : DataFrame
+        A value to plot for each combination of the values of the x-axis variable (index) and of
+        the y-axis variable (columns)
+    grid_lw : int
+        Line width of the grid lines. Default is 2.
+
+    **pcolormesh_kwargs : dict
+        Additional keyword arguments are passed on to `pcolormesh`.
+
+    Returns:
+    ax : Axes
+       Matplotlib Axes object
+    pcm : QuadMesh
+       Matplotlib object returned by `pcolormesh`.
+    """
+
+    # Re-order data to match pmf1, pmf2
+    data = data.loc[pmf1.index, pmf2.index]
+    # Create axes for the copula plot
+    ax, x_mesh, y_mesh = _create_copula_axes(fig, pmf1, pmf2, grid_lw=grid_lw)
+    # Plot the copula data on a pcolormesh
+    pcm = ax.pcolormesh(x_mesh, y_mesh, data, **pcolormesh_kwargs)
+    return ax, pcm

--- a/tests/test_empirical_copula.py
+++ b/tests/test_empirical_copula.py
@@ -6,6 +6,7 @@ from empirical_copula import (
     empirical_marginal_pmf,
     independent_pmf,
     joint_counts,
+    order_from_pmf,
 )
 
 
@@ -92,3 +93,15 @@ def test_empirical_pmf():
         ]
     )
     assert_frame_equal(expected_empirical_pmf, empirical_pmf)
+
+
+def test_order_from_pmf():
+    pmf = pd.Series(data=[0.3, 0.4, 0.1], index=['A', 'B', 'C'])
+    # when ordinal
+    expected = ['A', 'B', 'C']
+    order = order_from_pmf(pmf, is_ordinal=True)
+    assert order == expected
+    # when non-ordinal
+    expected = ['B', 'A', 'C']
+    order = order_from_pmf(pmf, is_ordinal=False)
+    assert order == expected

--- a/tests/test_empirical_copula.py
+++ b/tests/test_empirical_copula.py
@@ -10,18 +10,12 @@ from empirical_copula import (
 )
 
 
-def test_empirical_marginals_categorical():
+def test_empirical_marginals():
     samples = pd.Series(['A', 'B', 'A', 'F', 'B', 'B'])
     expected = pd.Series(data=[3.0/6.0, 2.0/6.0, 1.0/6.0], index=['B', 'A', 'F'])
-    pmf = empirical_marginal_pmf(samples, is_ordinal=False)
-    assert_series_equal(expected, pmf)
-
-
-def test_empirical_marginals_ordinal():
-    samples = pd.Series(['A', 'B', 'A', 'F', 'B', 'B'])
-    expected = pd.Series(data=[2.0/6.0, 3.0/6.0, 1.0/6.0], index=['A', 'B', 'F'])
-    pmf = empirical_marginal_pmf(samples, is_ordinal=True)
-    assert_series_equal(expected, pmf)
+    pmf = empirical_marginal_pmf(samples)
+    # Re-order according to pmf index to be order-agnostic
+    assert_series_equal(expected.loc[pmf.index], pmf)
 
 
 def test_joint_counts():
@@ -30,8 +24,6 @@ def test_joint_counts():
               [100, 200, 100, 100, 300, 300]],
         index=['v1', 'v2']
     ).T
-    order1 = ['B', 'A', 'F']
-    order2 = [100, 200, 300]
     expected = pd.DataFrame(
         index=['B', 'A', 'F'],
         columns=[100, 200, 300],
@@ -41,8 +33,9 @@ def test_joint_counts():
             [0, 0, 1],
         ]
     )
-    counts = joint_counts(samples, order1=order1, order2=order2)
-    assert_frame_equal(expected, counts, check_names=False)
+    counts = joint_counts(samples)
+    # Re-order according to counts indices to be order-agnostic
+    assert_frame_equal(expected.loc[counts.index, counts.columns], counts, check_names=False)
 
 
 def test_independent_pmf():
@@ -58,7 +51,8 @@ def test_independent_pmf():
         ]
     )
     pmf = independent_pmf(pmf1, pmf2)
-    assert_frame_equal(expected, pmf)
+    # Re-order according to `counts` indices to be order-agnostic
+    assert_frame_equal(expected.loc[pmf.index], pmf)
 
 
 def test_empirical_pmf():
@@ -68,8 +62,7 @@ def test_empirical_pmf():
         index=['v1', 'v2']
     ).T
 
-    pmf1, pmf2, empirical_pmf, others = empirical_joint_pmf_details(
-        samples, is_col1_ordinal=True, is_col2_ordinal=True)
+    pmf1, pmf2, empirical_pmf, others = empirical_joint_pmf_details(samples)
 
     n = float(samples.shape[0])
     expected_joint_freq = pd.DataFrame(
@@ -81,7 +74,9 @@ def test_empirical_pmf():
             [0.0/n, 1.0/n],
         ]
     )
-    assert_frame_equal(expected_joint_freq, others['joint_freq'])
+    # Re-order according to `joint_freq` indices to be order-agnostic
+    joint_freq = others['joint_freq']
+    assert_frame_equal(expected_joint_freq.loc[joint_freq.index, joint_freq.columns], joint_freq)
 
     expected_empirical_pmf = pd.DataFrame(
         index=['A', 'B', 'F'],
@@ -92,7 +87,9 @@ def test_empirical_pmf():
             [0.0, 1.0 * n  / (1 * 5)],
         ]
     )
-    assert_frame_equal(expected_empirical_pmf, empirical_pmf)
+    # Re-order according to `empirical_pmf` indices to be order-agnostic
+    assert_frame_equal(expected_empirical_pmf.loc[empirical_pmf.index, empirical_pmf.columns],
+                       empirical_pmf)
 
 
 def test_order_from_pmf():

--- a/tests/test_empirical_copula.py
+++ b/tests/test_empirical_copula.py
@@ -6,7 +6,7 @@ from empirical_copula import (
     empirical_marginal_pmf,
     independent_pmf,
     joint_counts,
-    order_from_pmf,
+    order_pmf,
 )
 
 
@@ -94,11 +94,17 @@ def test_empirical_pmf():
 
 def test_order_from_pmf():
     pmf = pd.Series(data=[0.3, 0.4, 0.1], index=['A', 'B', 'C'])
+
     # when ordinal
     expected = ['A', 'B', 'C']
-    order = order_from_pmf(pmf, is_ordinal=True)
+    ordered_pmf = order_pmf(pmf, is_ordinal=True)
+    order = ordered_pmf.index.tolist()
     assert order == expected
+    assert_series_equal(ordered_pmf, pmf.loc[order])
+
     # when non-ordinal
     expected = ['B', 'A', 'C']
-    order = order_from_pmf(pmf, is_ordinal=False)
+    ordered_pmf = order_pmf(pmf, is_ordinal=False)
+    order = ordered_pmf.index.tolist()
     assert order == expected
+    assert_series_equal(ordered_pmf, pmf.loc[order])


### PR DESCRIPTION
The ordering can be done on the pmfs if needed using `order_pmf`.

A new plotting function makes sure that the copula values are plotted following the pmfs orders.

Fix #12 